### PR TITLE
解决与rename-file插件和compress插件的兼容问题

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 #test
+/lib

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "author": "Dec-F",
   "license": "MIT",
   "devDependencies": {
+    "@types/fs-extra": "^9.0.12",
     "@types/node": "^12.12.21",
     "@types/sharp": "^0.23.1",
     "@typescript-eslint/eslint-plugin": "^2.7.0",
@@ -49,6 +50,9 @@
     "typescript": "^3.7.2"
   },
   "dependencies": {
+    "color": "^3.1.3",
+    "dayjs": "^1.10.6",
+    "fs-extra": "^10.0.0",
     "sharp": "^0.23.4",
     "text-to-svg": "^3.1.5"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "picgo-plugin-watermark",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "PicGo's watermark plugin",
   "main": "./lib/index.js",
   "bin": {},
@@ -35,6 +35,9 @@
     "picgo-gui-plugin"
   ],
   "author": "Dec-F",
+  "contributors": [
+    "panyanbin <me@panyanbin.com> (https://www.panyanbin.com)"
+  ],
   "license": "MIT",
   "devDependencies": {
     "@types/fs-extra": "^9.0.12",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,10 +1,20 @@
 import Picgo from "picgo";
-import { PluginConfig } from "picgo/dist/src/utils/interfaces";
+import { IPluginConfig } from "picgo/dist/src/utils/interfaces";
 
-export const config: (ctx: Picgo) => PluginConfig[] = ctx => {
-  let userConfig = ctx.getConfig("picgo-plugin-watermark");
+import {IConfig} from './util'
+
+export const config: (ctx: Picgo) => IPluginConfig[] = ctx => {
+  let userConfig = ctx.getConfig<IConfig>("picgo-plugin-watermark");
   if (!userConfig) {
-    userConfig = {};
+    userConfig = {
+      image: '',
+      fontFamily: '',
+      fontSize: '',
+      textColor: '',
+      minSize: '',
+      position: '',
+      text: '',
+    };
   }
   return [
     {
@@ -22,6 +32,14 @@ export const config: (ctx: Picgo) => PluginConfig[] = ctx => {
       required: false,
       message: "文字，默认只支持英文，中文支持需要配置字体文件路径",
       alias: "水印文字"
+    },
+    {
+      name: "textColor",
+      type: "input",
+      default: userConfig.textColor,
+      required: false,
+      message: "文字的颜色，支持rgb和hex格式，如rgb(178, 178, 178)或#b2b2b2",
+      alias: "水印文字颜色"
     },
     {
       name: "fontSize",

--- a/src/input.ts
+++ b/src/input.ts
@@ -1,0 +1,95 @@
+import Picgo from "picgo";
+import dayjs from 'dayjs';
+import fs from 'fs-extra'
+
+import sharp from "sharp";
+import path from "path";
+import Logger from "picgo/dist/src/lib/Logger";
+import { getCoordinateByPosition, PositionType, getImageBufferData } from "./util";
+
+interface IInput {
+  input: any[];
+  minWidth: number;
+  minHeight: number;
+  position: string;
+  waterMark: string | Buffer;
+}
+
+export const inputAddWaterMarkHandle: (
+  ctx: Picgo,
+  iinput: IInput,
+  logger: Logger
+) => Promise<string[]> = async (ctx, imageInput, logger) => {
+  const { input, minWidth, minHeight, waterMark, position } = imageInput;
+  const sharpedWaterMark = sharp(waterMark);
+  const waterMarkMeta = await sharpedWaterMark.metadata();
+
+  const addedWaterMarkInput = await Promise.all(
+    input.map(async image => {
+      let addWaterMarkImagePath = '';
+
+      // get image buffer data
+      const imageBuffer = await getImageBufferData(ctx, image)
+
+      const sharpedImage = sharp(imageBuffer);
+
+      const { width, height, format } = await sharpedImage.metadata();
+      const coordinate = getCoordinateByPosition({
+        width,
+        height,
+        waterMark: {
+          width: waterMarkMeta.width,
+          height: waterMarkMeta.height,
+          position: PositionType[position]
+        }
+      });
+      logger.info(JSON.stringify(coordinate));
+      logger.info(`watermark 图片文件格式：${format}`)
+
+      // Picture width or length is too short, do not add watermark
+      // Or trigger minimum size limit
+      if (
+        coordinate.left <= 0 ||
+        coordinate.top <= 0 ||
+        width <= minWidth ||
+        height <= minHeight
+      ) {
+        addWaterMarkImagePath = image;
+        logger.info('watermark 图片尺寸不满足，跳过水印添加')
+      } else {
+        // 如果图片是 picgo 生成的图片，则说明是剪切板图片
+        // https://github.com/PicGo/PicGo-Core/blob/85ecd16253ea58910de63511ea95e6f6fb6249d6/src/utils/getClipboardImage.ts#L25
+        if (ctx.baseDir === path.dirname(image)) {
+          addWaterMarkImagePath = image
+        } else {
+          // not a clipboard image, generate a new file to save watermark image
+          // 如果不是剪切板图片，说明图片为通过拖拽或选择的本地图片、或者是网络图片的url，需要在 picgo 目录下生成一个图片
+          // 用于存放添加水印后的图片
+          const extname = format || path.extname(image) || 'png'
+          addWaterMarkImagePath = path.join(ctx.baseDir, `${dayjs().format('YYYYMMDDHHmmss')}.${extname}`)
+
+          ctx.once('failed', () => {
+            // 删除 picgo 生成的图片文件，例如 `~/.picgo/20200621205720.png`
+            fs.remove(addWaterMarkImagePath).catch((e) => { ctx.log.error(e) })
+          })
+          ctx.once('finished', () => {
+            // 删除 picgo 生成的图片文件，例如 `~/.picgo/20200621205720.png`
+            fs.remove(addWaterMarkImagePath).catch((e) => { ctx.log.error(e) })
+          })
+        }
+
+        await sharpedImage
+          .composite([
+            {
+              input: await sharpedWaterMark.toBuffer(),
+              ...coordinate
+            }
+          ]).toFile(addWaterMarkImagePath)
+
+        logger.info('watermark 水印添加成功')
+      }
+      return addWaterMarkImagePath
+    })
+  );
+  return addedWaterMarkInput;
+};

--- a/src/text2svg.ts
+++ b/src/text2svg.ts
@@ -9,5 +9,18 @@ export const getSvg = (
   text: string,
   options?: { fontSize?: number; [propName: string]: any }
 ): string => {
-  return textToSVG.getSVG(text, { ...fontOptions, ...options });
+  const svgOptions: {[propName: string]: any} = {
+    attributes: {},
+    ...fontOptions
+  }
+  if (options) {
+    svgOptions.attributes = {
+      ...svgOptions.attributes,
+      ...options
+    }
+    if (options.fontSize) {
+      svgOptions.fontSize = options.fontSize
+    }
+  }
+  return textToSVG.getSVG(text, svgOptions);
 };

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,3 +1,7 @@
+import fs from 'fs-extra'
+import Picgo from "picgo";
+import Color from 'color';
+
 import { OFFSET } from "./attr";
 
 export enum PositionType {
@@ -12,7 +16,7 @@ export enum PositionType {
   rb = "right-bottom"
 }
 
-interface Coordinate {
+interface ICoordinate {
   left: number;
   top: number;
 }
@@ -24,7 +28,7 @@ export const getCoordinateByPosition = (prop: {
     height: number;
     position: PositionType;
   };
-}): Coordinate => {
+}): ICoordinate => {
   const { width, height, waterMark } = prop;
   const p = waterMark.position.split("-");
   return p.reduce(
@@ -55,8 +59,9 @@ export const getCoordinateByPosition = (prop: {
   );
 };
 
-export interface Config {
+export interface IConfig {
   text: string;
+  textColor: string;
   position: string;
   fontSize: string;
   image: string;
@@ -67,11 +72,11 @@ export interface Config {
   parsedFontSize?: number;
 }
 export const parseAndValidate: (
-  config: Config
-) => [string[], Config] = config => {
-  const { position, fontSize, minSize } = config;
+  config: IConfig
+) => [string[], IConfig] = config => {
+  const { position, fontSize, minSize, textColor } = config;
   const parsedFontSize = parseInt(fontSize);
-  let parsedConfig: Config = { ...config };
+  let parsedConfig: IConfig = { ...config };
   let errors = [];
   // 无效数字且不为空
   if (isNaN(parsedFontSize) && fontSize !== null) {
@@ -91,6 +96,13 @@ export const parseAndValidate: (
       parsedConfig.minWidth = minWidth;
     }
   }
+  if (textColor) {
+    try {
+      parsedConfig.textColor = Color(textColor).hex()
+    } catch (error) {
+      errors.push('textColor')
+    }
+  }
   return [
     errors,
     {
@@ -99,3 +111,29 @@ export const parseAndValidate: (
     }
   ];
 };
+
+// 是否是网络图片
+export const isUrl: (url: string) => boolean = (url) => {
+  return /^https?:\/\//.test(url)
+}
+
+export const downloadImage: (ctx: Picgo, url: string) => Promise<Buffer> = async (ctx, url) => {
+  return await ctx.request({ method: 'GET', url, encoding: null })
+    .on('error', function(err) {
+      ctx.log.error(`网络图片下载失败，${url}`)
+      ctx.log.error(err)
+    }).on('response', (response: Response): void => {
+      const contentType = response.headers['content-type']
+      if (contentType && !contentType.includes('image')) {
+        throw new Error(`${url} is not image`)
+      }
+  })
+}
+
+export const getImageBufferData: (ctx: Picgo, imageUrl: string) => Promise<Buffer> = (ctx, imageUrl) => {
+  if (isUrl(imageUrl)) {
+    return downloadImage(ctx, imageUrl)
+  } else {
+    return fs.readFile(imageUrl)
+  }
+}


### PR DESCRIPTION
1、调整水印添加的时间节点为beforeTransform，因此图片可以先加水印后处理压缩等功能
2、解决与rename-file插件的文件重命名冲突问题
3、解决与compress插件一起使用时，图片压缩不生效的兼容问题；
4、新增支持水印中文字颜色自定义的小功能；