### PR TITLE
更新 sharp 版本，处理安装失败问题

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 #test
 /lib
+/scripts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [1.1.0](https://github.com/Dec-F/picgo-plugin-watermark/compare/v1.0.0...v1.1.0) (2021-07-15)
+
 ## [1.0.0](https://github.com/Dec-F/picgo-plugin-watermark/compare/v0.1.2...v1.0.0) (2020-02-26)
 
 ### [0.1.2](https://github.com/Dec-F/picgo-plugin-watermark/compare/v0.1.1...v0.1.2) (2020-02-26)

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
   "files": [
     "lib",
     "logo.png",
-    "scripts",
-    "external"
+    "scripts"
   ],
   "repository": {
     "type": "git",
@@ -56,7 +55,10 @@
     "color": "^3.1.3",
     "dayjs": "^1.10.6",
     "fs-extra": "^10.0.0",
-    "sharp": "^0.23.4",
+    "sharp": "^0.28.3",
     "text-to-svg": "^3.1.5"
+  },
+  "engines": {
+    "node": ">10.0.0"
   }
 }

--- a/scripts/rebuild.js
+++ b/scripts/rebuild.js
@@ -1,20 +1,77 @@
 const platform = require("os").platform;
-const fs = require("fs");
+const fs = require("fs-extra");
 const path = require("path");
+
+const sharpNodeUrl =`https://raw.githubusercontent.com/fhyoga/picgo-plugin-watermark/v1.0.0/external/sharp/${platform}/sharp.node`;
+
+const downloadFile = (url, dest) => {
+  return new Promise((resolve, reject) => {
+    var ws = fs.createWriteStream(dest);
+    const request = /^https:\/\//.test(url) ? require('https') : require('http')
+    request.get(url, (response) => {
+      if (response.statusCode !== 200) {
+        reject(response.statusMessage)
+        return
+      }
+      console.log('sharp.node file is downloading...')
+      response.pipe(ws);
+      ws.on('finish', () => {
+        console.log('')
+        console.log('sharp.node download complete')
+        ws.close();
+        resolve()
+      });
+      response.on('data', () => {
+        process.stdout.write('=')
+      })
+    }).on('error', (err) => { 
+      // Handle errors
+      // Delete the file async. (But we don't check the result)
+      console.log('')
+      console.log('sharp.node download fail')
+      fs.unlink(dest, () => {});
+      reject(err.message)
+    })
+  })
+}
 
 // is CI?
 console.log(process.env.SKIP_REBUILD);
 if (process.env.SKIP_REBUILD) return
 
-
-const sourcePath = path.join(
-  __dirname,
-  `../external/sharp/${platform}/sharp.node`
-);
-const targetPath = path.join(
-  __dirname,
-  `../../../node_modules/sharp/build/Release/sharp.node`
-);
-fs.rename(sourcePath, targetPath, err => {
-  if (err) throw new Error("copy sharp error");
-});
+(async () => {
+  const targetDir = path.join(
+    __dirname,
+    `../../../node_modules/sharp`
+  )
+  // as a npm package to install 
+  if (fs.existsSync(targetDir)) {
+    const targetPath = path.join(
+      __dirname,
+      `../../../node_modules/sharp/build/Release/sharp.node`
+    );
+    // Most modern macOS, Windows and Linux systems
+    // sharp(0.28.3) package will auto fetch sharp.node file
+    if (!fs.existsSync(targetPath)) {
+      const sourcePath = path.join(
+        __dirname,
+        `../external/sharp/${platform}/sharp.node`
+      );
+      if (!fs.existsSync(sourcePath)) {
+        try {
+          fs.mkdirpSync(path.dirname(sourcePath))
+          // download sharp.node
+          await downloadFile(sharpNodeUrl, sourcePath)
+        } catch (error) {
+          throw new Error(error)
+        }
+      }
+      try {
+        await fs.rename(sourcePath, targetPath);
+      } catch (error) {
+        throw new Error("copy sharp error")
+      }
+    }
+  }
+  console.log('watermark plugin install completed')
+})()


### PR DESCRIPTION
1. 更新sharp版本到0.28.3，旧版本库安装依赖时，其需要本地先有python环境，否则报错安装失败
2. 新版本sharp自动兼容请求各个系统环境的sharp.node编译包，一般不需要我们介入请求编译包
3. 若存在sharp包无法请求包时，自动请求存放在github中的node包，减少npm包的体积以减少包请求时间